### PR TITLE
Add --team commandline flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ From your GOPATH:
 ## Commandline options
 
 `--repos`: Comma-delimited list of repositories. This is generally the Github or Bitbucket path.
+`--team`: Team slug for a team you want to watch. Setting this will override the repos setting.
 `--datasource`: Specifies the location of your `drone.sqlite` file
 `--port`: Port to listen on (i.e. `--port=:8080`)
 

--- a/templates/watcher.html
+++ b/templates/watcher.html
@@ -6,8 +6,8 @@
 		<title>Drone Watcher</title>
 		<meta charset="utf-8">
 		
-		<link rel="stylesheet" href="/css/normalize.css">
-		<link rel="stylesheet" href="/css/watcher.css">
+		<link rel="stylesheet" href="css/normalize.css">
+		<link rel="stylesheet" href="css/watcher.css">
 		<link rel="stylesheet" href="//netdna.bootstrapcdn.com/font-awesome/4.0.3/css/font-awesome.css">
 		
 	</head>
@@ -57,11 +57,11 @@
 		</main>
 
 		<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.2.12/angular.min.js"></script>
-		<script src="/js/app.js"></script>
-		<script src="/js/services.js"></script>
-		<script src="/js/controllers.js"></script>
-		<script src="/js/filters.js"></script>
-		<script src="/js/directives.js"></script>
+		<script src="js/app.js"></script>
+		<script src="js/services.js"></script>
+		<script src="js/controllers.js"></script>
+		<script src="js/filters.js"></script>
+		<script src="js/directives.js"></script>
 
 	</body>
 


### PR DESCRIPTION
A little cleanup and added a `--team` commandline flag. When `--team` is set to the slug of a particular team, all repos in that team are watched and displayed on the wall. This setting overrides the `--repos` flag if both are provided.
