### PR TITLE
Adding API_PORT for drone installations not on port 80/443

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ drone-wall
 
     $ docker pull scottwferg/drone-wall
     $ docker run -p 3000:3000 -e API_SCHEME=$API_SCHEME -e API_DOMAIN=$API_DOMAIN \
-        -e API_TOKEN=$API_TOKEN scottwferg/drone-wall
+        -e API_TOKEN=$API_TOKEN -e API_PORT=$API_PORT scottwferg/drone-wall
 
 Drone wall exposes port `3000`. You can map this to whatever you like.
 
 The `API_` variables are required to configure the route that's hit to find new Drone builds.  
 `SCHEME` accepts HTTP or HTTPS, `DOMAIN` is where you provide the domain that is hosting the 
-API, and `TOKEN` is where you should paste the access token that will authenticate you with 
+API, `PORT` sets the port for the api host (default 443 for https and 80 for http), and `TOKEN` is where you should paste the access token that will authenticate you with 
 the Drone API (found in your Drone user settings).

--- a/server.js
+++ b/server.js
@@ -20,6 +20,7 @@ var serveFeed = function ( req, res, next )
 {
     var apiScheme = process.env.API_SCHEME || "https";
     var apiDomain = process.env.API_DOMAIN || "";
+    var apiPort   = process.env.API_PORT || (apiScheme == "https" ? 443 : 80);
     var apiToken  = process.env.API_TOKEN  || "";
 
     var path   = "/api/user/feed?access_token=" + apiToken;
@@ -28,6 +29,7 @@ var serveFeed = function ( req, res, next )
     var req = client.get(
     {
         "host": apiDomain,
+        "port": apiPort,
         "path": path
 
     }, function( result )


### PR DESCRIPTION
Allows drone to be running on a custom port.
