### PR TITLE
Rename port envvar

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 RUN npm install -g bower
 RUN npm install -g grunt-cli
 RUN bower --allow-root install
-RUN grunt deploy --force
+RUN grunt deploy
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN npm install
 RUN npm install -g bower
 RUN npm install -g grunt-cli
 RUN bower --allow-root install
-RUN grunt deploy
+RUN grunt deploy --force
 
 EXPOSE 3000
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function( grunt )
             options:
             {
                 mangle: true,
-                compress: true,
+                compress: {},
                 banner: "/*! <%= pkg.name %> <%= grunt.template.today( 'yyyy-mm-dd' ) %> */",
                 sourceMap: true,
                 sourceMapName: "build/project.js.map"

--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ drone-wall
 
 ### Deployment
 
-    $ docker pull scottwferg/drone-wall
-    $ docker run -p 3000:3000 -e API_SCHEME=$API_SCHEME -e API_DOMAIN=$API_DOMAIN \
-        -e API_TOKEN=$API_TOKEN -e API_PORT=$API_PORT scottwferg/drone-wall
+    $ docker pull scottwferg/drone-wall:2.1
+    $ docker run -p 3000:8080 -e API_SCHEME=$API_SCHEME -e API_DOMAIN=$API_DOMAIN \
+        -e API_TOKEN=$API_TOKEN -e API_PORT=$API_PORT -e WALL_PORT=8080 scottwferg/drone-wall:2.1
 
 Drone wall exposes port `3000`. You can map this to whatever you like.
 
 The `API_` variables are required to configure the route that's hit to find new Drone builds.  
 `SCHEME` accepts HTTP or HTTPS, `DOMAIN` is where you provide the domain that is hosting the 
-API, `PORT` sets the port for the api host (default 443 for https and 80 for http), and `TOKEN` is where you should paste the access token that will authenticate you with 
+API, `WALL_PORT` sets the port for the api host (default 443 for https and 80 for http), and `TOKEN` is where you should paste the access token that will authenticate you with 
 the Drone API (found in your Drone user settings).

--- a/server.js
+++ b/server.js
@@ -57,4 +57,4 @@ var serveFeed = function ( req, res, next )
 app.route( "/api/feed" ).get( serveFeed );
 app.route( "*" ).get( serveIndex );
 
-http.createServer( app ).listen( process.env.PORT || 3000 );
+http.createServer( app ).listen( process.env.WALL_PORT || 3000 );


### PR DESCRIPTION
Do not use the $PORT env var because it doesn't allow you to use drone-wall in mesos environments.